### PR TITLE
feat: 피드백 생성 시 멘토-멘티 관계 세팅, 피드백 삭제 시 관계 세팅 해제

### DIFF
--- a/src/main/java/com/example/talkenbackend/feedback/repository/FeedbackQueryDslRepository.java
+++ b/src/main/java/com/example/talkenbackend/feedback/repository/FeedbackQueryDslRepository.java
@@ -14,10 +14,13 @@ import static com.example.talkenbackend.feedback.domain.QFeedback.feedback;
 @Repository
 public class FeedbackQueryDslRepository {
     private final JPAQueryFactory queryFactory;
-//    public List<Feedback> searchBy(String region) {
-//        return queryFactory
-//                .selectFrom(feedback)
-////                .where(feedback.region.eq(region))
-//                .fetch();
-//    }
+
+    public List<Feedback> findByMentorIdAndMenteeId(Long mentorId, Long menteeId) {
+        return queryFactory
+                .selectFrom(feedback)
+                .where(feedback.menteeId.eq(menteeId)
+                        .and(feedback.mentorId.eq(mentorId)))
+                .fetch();
+    }
+
 }

--- a/src/main/java/com/example/talkenbackend/relation/domain/Relation.java
+++ b/src/main/java/com/example/talkenbackend/relation/domain/Relation.java
@@ -1,0 +1,21 @@
+package com.example.talkenbackend.relation.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Entity
+public class Relation {
+    @Id @GeneratedValue
+    private Long id;
+    private Long fromUserId;
+    private Long toUserId;
+}

--- a/src/main/java/com/example/talkenbackend/relation/repository/RelationQueryDslRepository.java
+++ b/src/main/java/com/example/talkenbackend/relation/repository/RelationQueryDslRepository.java
@@ -1,0 +1,33 @@
+package com.example.talkenbackend.relation.repository;
+
+import com.example.talkenbackend.relation.domain.Relation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.example.talkenbackend.relation.domain.QRelation.relation;
+
+@RequiredArgsConstructor
+@Repository
+public class RelationQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public void deleteByFromUserIdAndToUserId(Long fromUserId, Long toUserId) {
+        queryFactory
+                .delete(relation)
+                .where(relation.fromUserId.eq(fromUserId)
+                        .and(relation.toUserId.eq(toUserId))).execute();
+        queryFactory
+                .delete(relation)
+                .where(relation.fromUserId.eq(toUserId)
+                        .and(relation.toUserId.eq(fromUserId))).execute();
+    }
+
+
+    public Relation findByFromUserIdAndToUserId(Long fromUserId, Long toUserId) {
+        return queryFactory.selectFrom(relation)
+                .where(relation.fromUserId.eq(fromUserId).and(
+                        relation.toUserId.eq(toUserId))).fetchOne();
+
+    }
+}

--- a/src/main/java/com/example/talkenbackend/relation/repository/RelationRepository.java
+++ b/src/main/java/com/example/talkenbackend/relation/repository/RelationRepository.java
@@ -1,0 +1,13 @@
+package com.example.talkenbackend.relation.repository;
+
+import com.example.talkenbackend.relation.domain.Relation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RelationRepository extends JpaRepository<Relation, Long> {
+    Optional<List<Relation>> findByFromUserId(Long fromUserId);
+}

--- a/src/main/java/com/example/talkenbackend/relation/service/RelationService.java
+++ b/src/main/java/com/example/talkenbackend/relation/service/RelationService.java
@@ -1,0 +1,42 @@
+package com.example.talkenbackend.relation.service;
+
+import com.example.talkenbackend.relation.domain.Relation;
+import com.example.talkenbackend.relation.repository.RelationQueryDslRepository;
+import com.example.talkenbackend.relation.repository.RelationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class RelationService {
+    private final RelationRepository relationRepository;
+    private final RelationQueryDslRepository relationQueryDslRepository;
+
+    public void unSetRelation(Long fromUserId, Long toUserId) {
+
+        relationQueryDslRepository.deleteByFromUserIdAndToUserId(fromUserId, toUserId);
+        relationQueryDslRepository.deleteByFromUserIdAndToUserId(toUserId, fromUserId);
+
+    }
+
+    public void setRelation(Long fromUserId, Long toUserId) {
+        Relation saved = relationQueryDslRepository.findByFromUserIdAndToUserId(fromUserId, toUserId);
+        if (saved!=null){ // 이미 세팅 된 관계
+            return;
+        }
+
+        // 양방향 저장
+        Relation relation = Relation.builder()
+                .fromUserId(fromUserId)
+                .toUserId(toUserId)
+                .build();
+        Relation relation2 = Relation.builder()
+                .fromUserId(toUserId)
+                .toUserId(fromUserId)
+                .build();
+        relationRepository.save(relation);
+        relationRepository.save(relation2);
+    }
+}


### PR DESCRIPTION
# Issue
- Number: #35 
- Status: 완료


# Motivations <!--무슨 이유로 코드를 변경했는지-->
- 멘토가 멘티의 이력서 혹은 포트폴리오에 피드백을 남기는 순간 멘토-멘티 관계가 성립된다.
- 멘토와 멘티의 관계 테이블 (Relation)을 따로 두어 빠르게 찾을 수 있도록 했다.
- 피드백을 삭제할 경우, 멘토가 멘티에게 남긴 피드백이 하나라도 있으면 관계가 해제되지 않고, 없다면 관계가 해제된다.

# Key Changes <!--주요 변경 사항, 리뷰어가 집중해서 봐야하는 것, 스크린 캡처 등-->
- querydsl repository가 추가
- 친구 관계, 피드백 조회 쿼리

# To Reviewers <!--리뷰어에게 하고싶은 말-->

